### PR TITLE
feat: default container for collector; fix interface typing

### DIFF
--- a/src/lib/collector.spec.ts
+++ b/src/lib/collector.spec.ts
@@ -54,6 +54,25 @@ describe("TryAsyncCollector", () => {
             pear: "pear",
         });
     });
+
+    it("allows interfaces to be passed in", async () => {
+        interface FooBar {
+            apple: string;
+            pear: number;
+            banana: boolean;
+        }
+        const foobar: FooBar = { apple: "apple", banana: false, pear: 1234 };
+        const result = await Collector.forTryAsync(foobar)
+            .fold("zig", () => TryAsync.success("zag"))
+            .yield()
+            .promise();
+        expect(result.get()).toEqual({
+            apple: "apple",
+            banana: false,
+            pear: 1234,
+            zig: "zag",
+        });
+    });
 });
 
 describe("TryCollector", () => {
@@ -103,6 +122,24 @@ describe("TryCollector", () => {
             apple: "apple",
             banana: "banana",
             pear: "pear",
+        });
+    });
+
+    it("allows interfaces to be passed in", () => {
+        interface FooBar {
+            apple: string;
+            pear: number;
+            banana: boolean;
+        }
+        const foobar: FooBar = { apple: "apple", banana: false, pear: 1234 };
+        const result = Collector.forTry(foobar)
+            .fold("zig", () => Try.success("zag"))
+            .yield()
+        expect(result.get()).toEqual({
+            apple: "apple",
+            banana: false,
+            pear: 1234,
+            zig: "zag",
         });
     });
 });

--- a/src/lib/collector.ts
+++ b/src/lib/collector.ts
@@ -40,11 +40,15 @@ import { Try } from "./try";
  */
 export abstract class Collector<O extends Record<string, unknown>> {
 
-    public static forTry<R extends Record<string, unknown>>(init: R = {} as R): TryCollector<R> {
+    // use of 'any' in typing is a known issue: https://github.com/microsoft/TypeScript/issues/15300
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public static forTry<R extends Record<string, any>>(init: R = {} as R): TryCollector<R> {
         return new TryCollector<R>(Try.of(() => init));
     }
 
-    public static forTryAsync<R extends Record<string, unknown>>(init: R | Promise<R> = {} as R): TryAsyncCollector<R> {
+    // use of 'any' in typing is a known issue: https://github.com/microsoft/TypeScript/issues/15300
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public static forTryAsync<R extends Record<string, any>>(init: R | Promise<R> = {} as R): TryAsyncCollector<R> {
         return new TryAsyncCollector<R>(TryAsync.of(init));
     }
 


### PR DESCRIPTION
- default Collector.forTry() to empty container
- default Collector.forTryAsync() to empty container
- fix typing for interfaces

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
