### PR TITLE
feat: add opt.toTry()

### DIFF
--- a/src/lib/optional.ts
+++ b/src/lib/optional.ts
@@ -221,6 +221,8 @@ export abstract class Optional<A> implements Monad<A> {
 
     /**
      * Converts this Optional into a Try. If empty, returns failure with given error. Otherwise, returns success
+     * @example Optional.of("foo").toTry(new MissingFoo()) => Try.success("foo")
+     * @example Optional.of(null).toTry(new MissingFoo()) => Try.failure(new MissingFoo())
      * @param {Error} error
      */
     public abstract toTry(error: Error): Try<A>;

--- a/src/lib/optional.ts
+++ b/src/lib/optional.ts
@@ -1,5 +1,6 @@
 import { Monad } from "./fantasy";
 import { OptionalAsync } from "./optional-async";
+import { Try } from "./try";
 
 export type Nil = undefined | null;
 
@@ -217,6 +218,12 @@ export abstract class Optional<A> implements Monad<A> {
     }
 
     public abstract case<B>(predicates: { some: (value: A) => Optional<B>; none: () => Optional<B> }): Optional<B>;
+
+    /**
+     * Converts this Optional into a Try. If empty, returns failure with given error. Otherwise, returns success
+     * @param {Error} error
+     */
+    public abstract toTry(error: Error): Try<A>;
 }
 
 export class Some<A> extends Optional<A> {
@@ -285,6 +292,10 @@ export class Some<A> extends Optional<A> {
     public case<B>(predicates: { some: (value: A) => Optional<B>; none: () => Optional<B> }): Optional<B> {
         return predicates.some(this.a);
     }
+
+    public toTry(): Try<A> {
+        return Try.success<A>(this.a);
+    }
 }
 
 export class None<A> extends Optional<A> {
@@ -346,6 +357,10 @@ export class None<A> extends Optional<A> {
 
     public case<B>(predicates: { some: (value: A) => Optional<B>; none: () => Optional<B> }): Optional<B> {
         return predicates.none();
+    }
+
+    public toTry(error: Error): Try<A> {
+        return Try.failure<A>(error);
     }
 }
 

--- a/tests/optional.spec.ts
+++ b/tests/optional.spec.ts
@@ -339,3 +339,20 @@ describe("Opt", () => {
         expect(opt.exists((s) => s === "foobar")).toBeTruthy();
     });
 });
+
+describe("toTry", () => {
+    it("returns a success if not empty", () => {
+        const error = new Error("expected");
+        const result = Optional.of("foobar").toTry(error);
+        expect(result.isSuccess()).toEqual(true);
+        expect(result.get()).toEqual("foobar");
+    });
+
+    it("returns a failure if not empty", () => {
+        const error = new Error("expected");
+        const result = Optional.of(undefined).toTry(error);
+        expect(result.isFailure()).toEqual(true);
+        expect(result.get).toThrow("expected");
+    });
+});
+


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

Optionals often need to be converted to tries via something like:
```
optional.map(Try.success).getOrElse(Try.failure(new Error()));
```


* **What is the new behavior (if this is a feature change)?**

Optionals will now have a utility function `toTry()`:
```
optional.toTry(new Error())
```
* **Other information**:
