### PR TITLE
feat: add 'void()' for Try and TryAsync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kfang/typescript-fp",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "utilities to deal with fp in typescript",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kfang/typescript-fp",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "description": "utilities to deal with fp in typescript",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/try-async.ts
+++ b/src/lib/try-async.ts
@@ -139,6 +139,10 @@ export class TryAsync<A> implements Monad<A> {
         return this.value;
     }
 
+    /**
+     * Maps the resolved value to `void` (undefined in this case). In other words, basically just throws away the
+     * resolved value. If this is a {@link Failure}, then it will continue to pass along the failure.
+     */
     public void(): TryAsync<void> {
         return this.map<void>(() => undefined);
     }

--- a/src/lib/try-async.ts
+++ b/src/lib/try-async.ts
@@ -138,4 +138,8 @@ export class TryAsync<A> implements Monad<A> {
     public promise(): Promise<Try<A>> {
         return this.value;
     }
+
+    public void(): TryAsync<void> {
+        return this.map<void>(() => undefined);
+    }
 }

--- a/src/lib/try.ts
+++ b/src/lib/try.ts
@@ -203,7 +203,7 @@ export abstract class Try<A> implements Monad<A> {
     public abstract readonly pFlatMap: <B>(fn: (a: A) => Promise<Try<B>>) => Promise<Try<B>>;
 
     /**
-     * applies the function to to an error. The function is only called if this is a Failure.
+     * applies the function to an error. The function is only called if this is a Failure.
      * This is useful if you want to provide a default value on a failure based on the error.
      * ```
      * Try.failure(new Error()).recover(() => "Hello World!");  // Success("Hello World!")
@@ -225,6 +225,13 @@ export abstract class Try<A> implements Monad<A> {
      */
     public abstract readonly recoverWith: (fn: (e: Error) => Try<A>) => Try<A>;
 
+    /**
+     * Maps the resolved value to `void` (undefined in this case). In other words, basically just throws away the
+     * resolved value. If this is a {@link Failure}, then it will continue to pass along the failure.
+     */
+    public void = (): Try<void> => {
+        return this.map<void>(() => undefined);
+    };
     public abstract case<B>(predicates: { success: (value: A) => Try<B>; failure: (error: Error) => Try<B> }): Try<B>;
 
     /**

--- a/tests/try-async.spec.ts
+++ b/tests/try-async.spec.ts
@@ -242,4 +242,16 @@ describe("void", () => {
         expect(result.isSuccess()).toEqual(true);
         expect(result.get()).toBeUndefined();
     });
+
+    it("converts a success to a void", async () => {
+        const result = await TryAsync.success("foobar").void().promise();
+        expect(result.isSuccess()).toEqual(true);
+        expect(result.get()).toBeUndefined();
+    });
+
+    it("passes along the failure", async () => {
+        const result = await TryAsync.failure(new Error("expected failure")).void().promise();
+        expect(result.isFailure()).toEqual(true);
+        expect(result.get).toThrow("expected failure");
+    });
 });

--- a/tests/try.spec.ts
+++ b/tests/try.spec.ts
@@ -350,4 +350,16 @@ describe("void", () => {
         expect(result.isSuccess()).toEqual(true);
         expect(result.get()).toBeUndefined();
     });
+
+    it("converts a success to a void", () => {
+        const result = Try.success("foobar").void();
+        expect(result.isSuccess()).toEqual(true);
+        expect(result.get()).toBeUndefined();
+    });
+
+    it("passes along the failure", () => {
+        const result = Try.failure(new Error("expected failure")).void();
+        expect(result.isFailure()).toEqual(true);
+        expect(result.get).toThrow("expected failure");
+    });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- adds `void()` method onto Try and TryAsync instance

