### PR TITLE
feat: add TryAsync.get()

### DIFF
--- a/src/lib/try-async.ts
+++ b/src/lib/try-async.ts
@@ -146,4 +146,8 @@ export class TryAsync<A> implements Monad<A> {
     public void(): TryAsync<void> {
         return this.map<void>(() => undefined);
     }
+
+    public get(): Promise<A> {
+        return this.promise().then((result) => result.get());
+    }
 }

--- a/tests/try-async.spec.ts
+++ b/tests/try-async.spec.ts
@@ -255,3 +255,15 @@ describe("void", () => {
         expect(result.get).toThrow("expected failure");
     });
 });
+
+describe("get", () => {
+    it("awaits and returns the value of a success", async () => {
+        const result = await TryAsync.success("success").get();
+        expect(result).toEqual("success");
+    });
+
+    it("awaits and throws the error of a failure", async () => {
+        const result = TryAsync.failure(new Error("expected failure")).get();
+        await expect(result).rejects.toThrow("expected failure");
+    });
+});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - adds a helper method `tryAsync.get()` to immediately await the TryAsync and call `.get()` on it
  - makes it easier to include TryAsync results in non-functional codebases
 
without .get():
```
const result = await TryAsync.of("meow")
    .promise()
    .then((result) =>  result.get())
```

with .get(): `const result = await TryAsync.of("meow").get()`
